### PR TITLE
Disable esModuleInterop for broader compatibility

### DIFF
--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -1,6 +1,7 @@
-import util from 'util'
-import zlib from 'zlib'
-import compress, {decompress} from '../index'
+import * as util from 'util'
+import * as zlib from 'zlib'
+import * as complete from '../index'
+import {compress, decompress} from '../index'
 
 describe('compress', () => {
   it('should return a stream transform', () => {
@@ -144,7 +145,7 @@ describe('compress', () => {
   })
 
   it('should provide the compress property that is the same function as the main export', () => {
-    expect(compress.compress).toBe(compress)
+    expect(compress).toBe(complete)
   })
 })
 

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import PluginError from 'plugin-error'
-import stream from 'stream'
-import through from 'through2'
-import zlib from 'zlib'
+import * as PluginError from 'plugin-error'
+import * as stream from 'stream'
+import * as through from 'through2'
+import * as zlib from 'zlib'
 
 type CompressFunctionType = typeof compress
 interface IExportedApi extends CompressFunctionType {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noFallthroughCasesInSwitch": true,
 
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": false
   },
   "exclude": [
     "__tests__"


### PR DESCRIPTION
Currently the TypeScript types don't work on projects that import `gulp-brotli` and don't have `esModuleInterop` enabled